### PR TITLE
custom fetcher

### DIFF
--- a/src/libs/errors/index.test.ts
+++ b/src/libs/errors/index.test.ts
@@ -7,6 +7,8 @@ import {
   InternalServerError,
   handleApiError,
   TooManyRequestsError,
+  HttpError,
+  getErrorStatus,
 } from "@/libs/errors";
 
 describe("libs/errors", () => {
@@ -45,28 +47,44 @@ describe("libs/errors", () => {
       const error = new BadRequestError();
       const response = handleApiError({ error });
 
-      expect(response).toStrictEqual({ message: "Bad Request", status: 400 });
+      expect(response).toStrictEqual({
+        message: "Bad Request",
+        status: 400,
+        originMessage: null,
+      });
     });
 
     test("if error is UnauthorizedError, return 401 status and Unauthorized message", () => {
       const error = new UnauthorizedError();
       const response = handleApiError({ error });
 
-      expect(response).toStrictEqual({ message: "Unauthorized", status: 401 });
+      expect(response).toStrictEqual({
+        message: "Unauthorized",
+        status: 401,
+        originMessage: null,
+      });
     });
 
     test("if error is ForbiddenError, return 403 status and Forbidden message", () => {
       const error = new ForbiddenError();
       const response = handleApiError({ error });
 
-      expect(response).toStrictEqual({ message: "Forbidden", status: 403 });
+      expect(response).toStrictEqual({
+        message: "Forbidden",
+        status: 403,
+        originMessage: null,
+      });
     });
 
     test("if error is NotFoundError, return 404 status and Not Found message", () => {
       const error = new NotFoundError();
       const response = handleApiError({ error });
 
-      expect(response).toStrictEqual({ message: "Not Found", status: 404 });
+      expect(response).toStrictEqual({
+        message: "Not Found",
+        status: 404,
+        originMessage: null,
+      });
     });
 
     test("if error is TooManyRequestsError, return 429 status and Too Many Requests message", () => {
@@ -76,6 +94,7 @@ describe("libs/errors", () => {
       expect(response).toStrictEqual({
         message: "Too Many Requests",
         status: 429,
+        originMessage: null,
       });
     });
 
@@ -86,6 +105,7 @@ describe("libs/errors", () => {
       expect(response).toStrictEqual({
         message: "Internal Server Error",
         status: 500,
+        originMessage: null,
       });
     });
 
@@ -97,6 +117,48 @@ describe("libs/errors", () => {
         message: "Internal Server Error",
         status: 500,
       });
+    });
+
+    test("if has originMessage, return originMessage", () => {
+      const error = new HttpError(400, "origin message");
+
+      const response = handleApiError({ error });
+
+      expect(response).toStrictEqual({
+        message: "Bad Request",
+        status: 400,
+        originMessage: "origin message",
+      });
+    });
+  });
+
+  describe("getErrorStatus", () => {
+    test("if status is 400, return 400", () => {
+      expect(getErrorStatus(400)).toBe(400);
+    });
+
+    test("if status is 401, return 401", () => {
+      expect(getErrorStatus(401)).toBe(401);
+    });
+
+    test("if status is 403, return 403", () => {
+      expect(getErrorStatus(403)).toBe(403);
+    });
+
+    test("if status is 404, return 404", () => {
+      expect(getErrorStatus(404)).toBe(404);
+    });
+
+    test("if status is 429, return 429", () => {
+      expect(getErrorStatus(429)).toBe(429);
+    });
+
+    test("if status is 500, return 500", () => {
+      expect(getErrorStatus(500)).toBe(500);
+    });
+
+    test("if status is unknown, return 500", () => {
+      expect(getErrorStatus(999)).toBe(500);
     });
   });
 });

--- a/src/libs/errors/index.ts
+++ b/src/libs/errors/index.ts
@@ -21,14 +21,24 @@ export type Error = {
 export class HttpError extends Error {
   message: ErrorsMessage;
 
-  constructor(public status: ErrorType) {
-    super();
+  originMessage: string | null;
+
+  constructor(
+    public status: ErrorType,
+    originMessage?: string | null
+  ) {
+    super(errors[status].message);
     this.message = errors[status].message;
     this.status = status;
+    this.originMessage = originMessage || null;
   }
 
   throwMessage() {
-    return { message: this.message, status: this.status };
+    return {
+      message: this.message,
+      status: this.status,
+      originMessage: this.originMessage,
+    };
   }
 }
 
@@ -68,6 +78,25 @@ export class InternalServerError extends HttpError {
   }
 }
 
+export const getErrorStatus = (status: number): ErrorType => {
+  switch (status) {
+    case 400:
+      return 400;
+    case 401:
+      return 401;
+    case 403:
+      return 403;
+    case 404:
+      return 404;
+    case 429:
+      return 429;
+    case 500:
+      return 500;
+    default:
+      return 500;
+  }
+};
+
 export const throwHttpErrorFromStatus = (status: ErrorType | number): never => {
   switch (status) {
     case 400:
@@ -92,41 +121,41 @@ export const handleApiError = ({ error }: { error: unknown }) => {
     const status = 400;
     const { message } = errors[status];
 
-    return { message, status };
+    return { message, status, originMessage: error.originMessage };
   }
 
   if (error instanceof UnauthorizedError) {
     const status = 401;
     const { message } = errors[status];
 
-    return { message, status };
+    return { message, status, originMessage: error.originMessage };
   }
 
   if (error instanceof ForbiddenError) {
     const status = 403;
     const { message } = errors[status];
 
-    return { message, status };
+    return { message, status, originMessage: error.originMessage };
   }
 
   if (error instanceof NotFoundError) {
     const status = 404;
     const { message } = errors[status];
 
-    return { message, status };
+    return { message, status, originMessage: error.originMessage };
   }
 
   if (error instanceof TooManyRequestsError) {
     const status = 429;
     const { message } = errors[status];
 
-    return { message, status };
+    return { message, status, originMessage: error.originMessage };
   }
 
   if (error instanceof HttpError) {
     const { status, message } = error.throwMessage();
 
-    return { message, status };
+    return { message, status, originMessage: error.originMessage };
   }
 
   const status = 500;

--- a/src/libs/fetch/index.test.ts
+++ b/src/libs/fetch/index.test.ts
@@ -1,0 +1,104 @@
+import { HttpError } from "@/libs/errors";
+import { get } from "@/libs/fetch";
+
+const exampleUrl = "https://example.com";
+const commonHeaders = {
+  "Content-Type": "application/json",
+};
+
+describe("libs/fetch", () => {
+  describe("get", () => {
+    const spyFetch = vi.spyOn(global, "fetch").mockImplementation(async () => {
+      const res = new Response(
+        JSON.stringify({
+          key: "value",
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      return res;
+    });
+
+    afterEach(() => {
+      spyFetch.mockClear();
+    });
+
+    test("should call fetch with correct url", async () => {
+      const params = { key: "value" };
+      const options = { params };
+
+      await get(exampleUrl, options);
+
+      expect(spyFetch).toBeCalledWith(`${exampleUrl}?key=value`, {
+        method: "GET",
+        headers: commonHeaders,
+      });
+    });
+
+    test("should call fetch with correct headers", async () => {
+      const headers = {
+        "X-API-KEY": "api key",
+      };
+
+      const options = { headers };
+
+      await get(exampleUrl, options);
+
+      expect(spyFetch).toBeCalledWith(exampleUrl, {
+        method: "GET",
+        headers: {
+          ...commonHeaders,
+          ...headers,
+        },
+      });
+    });
+
+    test("should call fetch with correct requestInit", async () => {
+      const requestInit: RequestInit = {
+        mode: "cors",
+      };
+
+      const options = { requestInit };
+
+      await get(exampleUrl, options);
+
+      expect(spyFetch).toBeCalledWith(exampleUrl, {
+        method: "GET",
+        headers: commonHeaders,
+        ...requestInit,
+      });
+    });
+
+    test("should return response json", async () => {
+      const response = await get(exampleUrl);
+
+      expect(response).toStrictEqual({ key: "value" });
+    });
+
+    test("should throw HttpError if response is not ok", async () => {
+      const errorFetch = vi
+        .spyOn(global, "fetch")
+        .mockImplementation(async () => {
+          const res = new Response("error message", {
+            status: 400,
+            headers: {
+              "Content-Type": "text/plain",
+            },
+          });
+
+          return res;
+        });
+
+      const expectError = new HttpError(400, "error message");
+
+      await expect(get(exampleUrl)).rejects.toThrow(expectError);
+
+      errorFetch.mockClear();
+    });
+  });
+});

--- a/src/libs/fetch/index.ts
+++ b/src/libs/fetch/index.ts
@@ -1,0 +1,46 @@
+import { HttpError, getErrorStatus } from "@/libs/errors";
+
+type Options<P extends Record<string, string>> = {
+  params?: P;
+  headers?: HeadersInit;
+  requestInit?: Omit<RequestInit, "headers" | "body" | "method">;
+};
+
+const createUrl = <P extends Record<string, string>>(
+  path: string,
+  params?: P
+): string => {
+  if (!params || Object.keys(params).length === 0) return path;
+
+  const searchParams = new URLSearchParams(params);
+
+  return `${path}?${searchParams.toString()}`;
+};
+
+export const get = async <T>(
+  path: string,
+  options?: Options<Record<string, string>>
+): Promise<T> => {
+  const url = createUrl(path, options?.params);
+
+  const res = await fetch(url, {
+    ...options?.requestInit,
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      ...options?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const originMessage = await res.text().catch(() => null);
+
+    const status = getErrorStatus(res.status);
+
+    const error = new HttpError(status, originMessage);
+
+    throw error;
+  }
+
+  return res.json();
+};


### PR DESCRIPTION
カスタムのfetchを定義

今回は、getしか使わない想定なのでそれに伴ってgetのfetchのみを追加している。
これに伴い、custom errorも修正している。
#9 statusの取得とオリジナルエラーメッセージの追加を行った。