### PR TITLE
fix Math.random in storybook

### DIFF
--- a/src/app/(apps)/_features/charts/components/legend/index.stories.tsx
+++ b/src/app/(apps)/_features/charts/components/legend/index.stories.tsx
@@ -84,7 +84,7 @@ export const BigData: Story = {
       inactive: false,
       dataKey: "value",
       type: "line",
-      color: `hsl(${(i * 360) % 360}deg, 60%, 60%)`,
+      color: `hsl(${i % 360}deg, 60%, 60%)`,
       value: `県${i}`,
     })),
   },

--- a/src/app/(apps)/_features/charts/components/legend/index.stories.tsx
+++ b/src/app/(apps)/_features/charts/components/legend/index.stories.tsx
@@ -84,7 +84,7 @@ export const BigData: Story = {
       inactive: false,
       dataKey: "value",
       type: "line",
-      color: `hsl(${(i * Math.random() * 360) % 360}deg, 60%, 60%)`,
+      color: `hsl(${(i * 360) % 360}deg, 60%, 60%)`,
       value: `県${i}`,
     })),
   },


### PR DESCRIPTION
GitHub Actionsが実行されなくなったので再度PR

Math.randomがstorybook内にあると毎回VRTが変更とみなされるので削除した。