### PR TITLE
cancel-workflow-actionの追加

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -1,0 +1,12 @@
+name: Cancel
+on: [push]
+jobs:
+  cancel:
+    name: "Cancel Previous Runs"
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+          workflow_id: "91830899, 91731804, 91743715, 91829154"


### PR DESCRIPTION
前のGitHub Actionsの実行を停止する、GitHub Actionsの追加