### PR TITLE
e2eテストの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # testing
 /coverage
 e2e/coverage
+screenshots/
 
 # next.js
 /.next/

--- a/e2e/mocks/api/index.ts
+++ b/e2e/mocks/api/index.ts
@@ -1,7 +1,9 @@
 import { mockFontHandlers } from "./google-fonts";
+import { mockPopulationHandler } from "./populations";
 import { mockPrefecturesHandler } from "./prefectures";
 
 export const mockSuccessAPIHandlers = [
   ...mockFontHandlers(),
   mockPrefecturesHandler(),
+  mockPopulationHandler(),
 ];

--- a/e2e/mocks/api/populations/index.ts
+++ b/e2e/mocks/api/populations/index.ts
@@ -1,0 +1,70 @@
+import {
+  RequestHandler,
+  rest,
+} from "next/experimental/testmode/playwright/msw";
+import { getTestEnv } from "../../env";
+import {
+  FetchPopulationResponse,
+  PopulationResult,
+} from "@/libs/types/api/populations";
+import { mockPopulation } from "@/tests/mocks/populations";
+
+type MockPopulationParams = {
+  status?: number;
+  delay?: number;
+};
+
+const errorResponse = {
+  statusCode: 403,
+  message: "Forbidden",
+  description: "You don't have permission to access this resource.",
+};
+
+const generateMockResponse = (): FetchPopulationResponse => {
+  const result: PopulationResult = {
+    boundaryYear: 2020,
+    data: [
+      {
+        label: "総人口",
+        data: mockPopulation,
+      },
+      {
+        label: "年少人口",
+        data: mockPopulation,
+      },
+      {
+        label: "生産年齢人口",
+        data: mockPopulation,
+      },
+      {
+        label: "老年人口",
+        data: mockPopulation,
+      },
+    ],
+  };
+
+  return { message: "Success", result };
+};
+
+export const mockPopulationHandler: (
+  params?: MockPopulationParams
+) => RequestHandler = (params) => {
+  return rest.get(
+    `${getTestEnv("URL")}/api/v1/population/composition/perYear`,
+    (_, res, ctx) => {
+      const { status = 200, delay = 0 } = params ?? {};
+
+      if (status >= 503) {
+        return res.networkError("Failed to connect");
+      }
+
+      const data = status >= 400 ? errorResponse : generateMockResponse();
+
+      return res(
+        ctx.status(status),
+        ctx.delay(delay),
+        ctx.json<FetchPopulationResponse>(data)
+      );
+    }
+  );
+};

--- a/e2e/page.spec.ts
+++ b/e2e/page.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "next/experimental/testmode/playwright/msw";
 import { mockSuccessAPIHandlers } from "./mocks/api";
+import { mockPrefectures } from "@/tests/mocks/prefectures";
 
 test.beforeEach(async ({ msw, page }) => {
   msw.use(...mockSuccessAPIHandlers);
@@ -9,4 +10,194 @@ test.beforeEach(async ({ msw, page }) => {
 
 test("renders the home page", async ({ page }) => {
   await expect(page).toHaveTitle("Poplus");
+});
+
+test("if select a checkbox, renders the population chart", async ({ page }) => {
+  const tokyoCheckbox = page.getByRole("checkbox", { name: "東京都" });
+
+  await tokyoCheckbox.click();
+
+  const chart = page.getByRole("region");
+
+  await expect(chart).toBeVisible();
+
+  expect(page).toHaveURL("/?prefCode=13");
+
+  await chart.screenshot({
+    path: "e2e/screenshots/population-chart.png",
+    animations: "allow",
+  });
+});
+
+test("if select a checkbox in the dialog, renders the population chart", async ({
+  page,
+}) => {
+  await page.goto("/?prefCode=13");
+  const dialogButton = page.getByRole("button", {
+    expanded: false,
+    name: "都道府県の選択 (1)",
+  });
+
+  await dialogButton.click();
+
+  const dialog = page.getByRole("dialog");
+
+  expect(dialog).toBeVisible();
+
+  const tokyoCheckbox = page.getByRole("checkbox", { name: "東京都" });
+
+  expect(tokyoCheckbox).toBeChecked();
+
+  const osakaCheckbox = page.getByRole("checkbox", { name: "大阪府" });
+
+  await osakaCheckbox.check();
+
+  await dialog.click();
+
+  const chart = page.getByRole("region");
+
+  await expect(chart).toBeVisible();
+
+  expect(page).toHaveURL("/?prefCode=13&prefCode=27");
+
+  await tokyoCheckbox.uncheck();
+
+  await expect(chart).toBeVisible();
+
+  expect(page).toHaveURL("/?prefCode=27");
+});
+
+test("batch toggle  button", async ({ page }) => {
+  const dialogButton = page.getByRole("button", {
+    expanded: false,
+    name: "都道府県の選択",
+  });
+
+  await dialogButton.click();
+
+  const dialog = page.getByRole("dialog");
+
+  expect(dialog).toBeVisible();
+
+  const allCheckButton = page.getByRole("link", { name: "すべて選択" });
+
+  await allCheckButton.click();
+
+  const chart = page.getByRole("region");
+
+  await expect(chart).toBeVisible();
+
+  const allURL = mockPrefectures
+    .map(({ prefCode }) => `prefCode=${prefCode}`)
+    .join("&");
+  expect(page).toHaveURL(`/?${allURL}&type=total`);
+
+  const resetButton = page.getByRole("link", { name: "リセット" });
+
+  expect(resetButton).toBeVisible();
+  await resetButton.click();
+
+  await expect(chart).toBeHidden();
+
+  expect(page).toHaveURL("/?type=total");
+});
+
+test("if hover chart, renders the tooltip", async ({ page }) => {
+  await page.goto("/?prefCode=13");
+
+  const chart = page.getByRole("region");
+
+  await chart.hover();
+
+  const tooltip = page.getByRole("tooltip");
+
+  await expect(tooltip).toBeVisible();
+});
+
+test("if change population type, to have new type", async ({ page }) => {
+  const typeButton = page.getByRole("button", { name: "総人口" });
+
+  await typeButton.click();
+
+  const dialog = page.getByRole("dialog");
+
+  await expect(dialog).toBeVisible();
+
+  await expect(page.getByRole("link", { name: "総人口" })).toBeVisible();
+
+  const youngLink = page.getByRole("link", {
+    name: "年少人口",
+  });
+
+  await expect(youngLink).toBeVisible();
+  await youngLink.click();
+
+  await expect(dialog).toBeHidden();
+
+  await expect(page).toHaveURL("/?type=young");
+
+  const checkbox = page.getByRole("checkbox", { name: "東京都" });
+
+  await checkbox.click();
+
+  const chart = page.getByRole("region");
+
+  await expect(chart).toBeVisible();
+
+  const label = page.locator(".recharts-label", {
+    hasText: "年少人口",
+  });
+
+  await expect(label).toBeVisible();
+
+  await chart.screenshot({
+    path: "e2e/screenshots/young-population-chart.png",
+    animations: "allow",
+  });
+});
+
+test("redirect test", async ({ page }) => {
+  await page.goto("/?prefCode=13");
+
+  await page.waitForURL("/?prefCode=13");
+
+  expect(page.getByRole("region")).toBeVisible();
+  expect(page).toHaveURL("/?prefCode=13");
+  const dialogButton = page.getByRole("button", {
+    expanded: false,
+    name: "都道府県の選択 (1)",
+  });
+
+  await dialogButton.click();
+
+  const dialog = page.getByRole("dialog");
+
+  expect(dialog).toBeVisible();
+
+  const tokyoCheckbox = page.getByRole("checkbox", { name: "東京都" });
+
+  expect(tokyoCheckbox).toBeChecked();
+
+  await tokyoCheckbox.uncheck();
+
+  await dialog.click();
+
+  await expect(page).toHaveURL("/");
+
+  await page.goto("/?prefCode=13&type=young");
+
+  await page.waitForURL("/?prefCode=13&type=young");
+
+  expect(page.getByRole("region")).toBeVisible();
+
+  await expect(page).toHaveURL("/?prefCode=13&type=young");
+
+  const chart = page.getByRole("region");
+  expect(chart).toBeVisible();
+
+  const label = page.locator(".recharts-label", {
+    hasText: "年少人口",
+  });
+
+  await expect(label).toBeVisible();
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",
-    "test:e2e:report": "pnpm playwright show-report",
+    "test:e2e:report": "pnpm playwright show-report e2e/coverage",
     "prepare": "husky",
     "sb": "storybook dev -p 6006",
     "sb:build": "storybook build",

--- a/src/tests/mocks/populations/index.ts
+++ b/src/tests/mocks/populations/index.ts
@@ -1,7 +1,7 @@
 import { FetchSelectedPopulationResponse } from "@/app/(apps)/_features/populations/types";
 import { Population } from "@/libs/types/api/populations";
 
-const mockPopulation: Population[] = [
+export const mockPopulation: Population[] = [
   {
     year: 1960,
     value: 100,


### PR DESCRIPTION
## PRの概要

**変更の目的**：

- e2eテストの追加

**関連するIssue番号**：

-  #13

## 変更内容

**実装した機能や修正したバグ**：

- e2eテストを追加した。

**技術的な実装詳細**：

- APIのmockにnext.js testmodeとmsw v1を使用している。
- [Qiita](https://qiita.com/Shilaca/items/076ce2fb2bcd8e1d9eb0)を参考にした。

## 確認項目

- [x] 単体テストを追加したか
- [x] 結合テスト/システムテストを更新したか
- [x] 自分の環境で全ての変更を検証したか

## 特記事項

**注意点**：

- next.js testmodeはexperimentalですが、使用しないとAPIのモックができないので使用した。

**デプロイメントの影響**：

- なし

## レビュワーへの質問

- なし
